### PR TITLE
Run "CI on main branch" for all commits on _main_ branch

### DIFF
--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -5,13 +5,15 @@ on:
         branches:
             - "main"
 
-# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 concurrency:
+    # We would like to run this workflow for all commits in the target branch.
+    # But we need to limit the workflow concurrency to ensure a deployment order as FIFO.
+    #
     # If we use `${{ github.workflow }}-${{ github.ref }}` and the invoked workflow for our `ci` job also has same group id,
     # this workflow will be cancelled by the invoked workflow's `concurrency` setting.
     # To avoid this problem, we use uuid v4 as a key to mark this workflow's uniqueness.
     group: "63f09107-e884-4366-b912-66ec06064c00"
-    cancel-in-progress: true
 
 jobs:
     ci:


### PR DESCRIPTION
This fixes the CI bug that runs only for the latest commits on _main_ branch. Trunk's CI should run for every commits to detect some problems early.