### PR TITLE
Run CI workflow for all commits on _main_ branch and give up to ensure FIFO order to run CI workflow for main branch.

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -1,16 +1,10 @@
-name: CI
+name: Shared CI workflow
 
 on:
     workflow_call:
-    pull_request:
 
 permissions:
     contents: read
-
-# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
-concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
 
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 # https://docs.github.com/en/actions/learn-github-actions/contexts

--- a/.github/workflows/ci_for_pr.yaml
+++ b/.github/workflows/ci_for_pr.yaml
@@ -1,0 +1,16 @@
+name: CI for each of Pull Requests
+
+on:
+    pull_request:
+
+permissions:
+    contents: read
+
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    ci:
+        uses: ./.github/workflows/_ci.yaml

--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -8,15 +8,22 @@ on:
 permissions:
     contents: read
 
-# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
-concurrency:
-    # We would like to run this workflow for all commits in the target branch.
-    # But we need to limit the workflow concurrency to ensure a deployment order as FIFO.
-    #
-    # If we use `${{ github.workflow }}-${{ github.ref }}` and the invoked workflow for our `ci` job also has same group id,
-    # this workflow will be cancelled by the invoked workflow's `concurrency` setting.
-    # To avoid this problem, we use uuid v4 as a key to mark this workflow's uniqueness.
-    group: "63f09107-e884-4366-b912-66ec06064c00"
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+#
+# We would like to run this workflow for all commits in the target branch.
+# But we also want to limit the workflow concurrency to ensure a deployment order as FIFO as possible.
+# At this moment, we use specify a group key to control the order of this kind of a workflow.
+# By GitHub's document, `concurrency.group` cancels all pending workflows in the queue
+# when we push a new change (`cancel-in-progress=true` works to cancel the workflow that has been invoked!).
+# This behavior does not achieve to ensure all commits will be deployed as FIFO order.
+#
+# `jobs.<job_id>.concurrency` can specify a job level concurrency similar to workflow level concurrency.
+# But it also lacks some features to ensure FIFO order for all commits.
+# So we don't have a way to ensure both of 1) FIFO order deployment. and 2) for all commits.
+#
+# Thus we don't limit the concurent running for this workflow to run this for all commits,
+# and give up to ensure FIFO order as the trade-off.
+# If we face a problem that causes an unexpected order for deployment, then we should rerun workflow by hands.....
 
 jobs:
     ci:

--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
     ci:
-        uses: ./.github/workflows/ci.yaml
+        uses: ./.github/workflows/_ci.yaml
 
     deploy:
         needs: [ci]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
     ci:
-        uses: ./.github/workflows/ci.yaml
+        uses: ./.github/workflows/_ci.yaml
 
     deploy:
         needs: [ci]


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

We would like to run this workflow for all commits in the target branch. But we also want to limit the workflow concurrency to ensure a deployment order as FIFO as possible.

At this moment, we use specify a group key to control the order of this kind of a workflow. By GitHub's document, `concurrency.group` cancels all pending workflows in the queue when we push a new change (`cancel-in-progress=true` works to cancel the workflow that has been invoked!). This behavior does not achieve to ensure all commits will be deployed as FIFO order.

`jobs.<job_id>.concurrency` can specify a job level concurrency similar to workflow level concurrency.
But it also lacks some features to ensure FIFO order for all commits. So we don't have a way to ensure both of 1) FIFO order deployment. and 2) for all commits.

Thus we don't limit the concurent running for this workflow to run this for all commits, and give up to ensure FIFO order as the trade-off. If we face a problem that causes an unexpected order for deployment, then we should rerun workflow by hands.....

This fixes some misunderstanding in #28 