### PR TITLE
Revive make lint_check

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -88,7 +88,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/ci_prepare_to_compile
             - shell: bash
-              run: make lint -j
+              run: make lint_check -j
 
     format_check:
         runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,14 @@ CARGO_FEATURES_CLI_FLAGS := \
     --features $(RELEASE_CHANNEL_FEATURES),$(ADDITIONAL_FEATURES)
 
 CLIPPY_RULES := \
-    -D rust-2018-idioms \
-    -D clippy::all
+    -W rust-2018-idioms \
+    -W clippy::all
+
+# We pass `-Dwarnings` flag to fail all warnings.
+# see https://doc.rust-lang.org/clippy/usage.html#command-line
+CLIPPY_RULES_FAIL_IF_WARNINGS :=\
+    $(CLIPPY_RULES) \
+    -Dwarnings
 
 
 all: help
@@ -143,6 +149,9 @@ __fastly_compute_validate_debug_build: __fastly_compute_pack_debug_build __clean
 ###########################
 lint: ## Run static analysis.
 	$(CARGO_BIN) clippy --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS) -- $(CLIPPY_RULES)
+
+lint_check: ## Run static analysis and fail if there are some warnings.
+	$(CARGO_BIN) clippy --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS) -- $(CLIPPY_RULES_FAIL_IF_WARNINGS)
 
 lint_fix: ## Try to fix problems found by static analytics
 	$(CARGO_BIN) clippy --fix --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS) -- $(CLIPPY_RULES)

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ check_integrity: ## Validate type and semantics for whole of codes by `cargo che
 lint_integration_tests: ## Run static analysis under integration_tests/
 	$(MAKE) lint -C $(INTEGRATION_TESTS_DIR)
 
-lint_check_integration_tests: ## Run static analysis under integration_tests/
+lint_check_integration_tests: ## Run static analysis under integration_tests/ and fail if there are some warnings.
 	$(MAKE) lint_check -C $(INTEGRATION_TESTS_DIR)
 
 lint_fix_integration_tests: ## Try to fix problems found by static analytics under integration_tests/


### PR DESCRIPTION
This just follow up https://github.com/tetsuharuohzeki/fastly-compute-at-edge-template/pull/57

---

By https://doc.rust-lang.org/clippy/usage.html#command-line,
we can failure the command if there are some all warnings by `-Dwarnings`.
Thus we revive `make lint_check`.