### PR TITLE
Pin Rust toolchain version for CI 

### DIFF
--- a/.github/actions/ci_prepare_to_compile/action.yaml
+++ b/.github/actions/ci_prepare_to_compile/action.yaml
@@ -7,7 +7,7 @@ runs:
         - name: Install Rust toolchain
           uses: actions-rs/toolchain@v1
           with:
-              toolchain: stable
+              toolchain: "1.64"
               profile: default
               target: wasm32-wasi
               override: false

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -101,7 +101,7 @@ jobs:
             - name: Install Rust toolchain
               uses: actions-rs/toolchain@v1
               with:
-                  toolchain: stable
+                  toolchain: "1.64"
                   profile: default
                   override: false
 


### PR DESCRIPTION
We use use clippy's warning as an error.
This might cause some failures on CI by rust toolchain's future release.

To keep CI as a green, we'd like to lock toolchain version.
For local development, we still allow to use an arbitrary _stable_ toolchain.