### PR TITLE
Replace actions-rs/toolchain with self defined composed action

### DIFF
--- a/.github/actions/ci_prepare_to_compile/action.yaml
+++ b/.github/actions/ci_prepare_to_compile/action.yaml
@@ -5,12 +5,12 @@ runs:
     using: composite
     steps:
         - name: Install Rust toolchain
-          uses: actions-rs/toolchain@v1
+          uses: ./.github/actions/rust-toolchain
           with:
               toolchain: "1.66"
               profile: default
               target: wasm32-wasi
-              override: false
+              override: true
 
         - uses: actions/cache@v3
           with:

--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -1,0 +1,82 @@
+name: rust-toolchain
+
+# This emulates https://github.com/actions-rs/toolchain#inputs
+inputs:
+    toolchain:
+        description: See https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
+        required: false
+        default: "stable"
+    target:
+        description: Space-separated list of target triple to be additionally installed.
+        required: false
+    default:
+        description: Whether to set the installed toolchain as default or not.
+        required: false
+        default: false
+    override:
+        description: Whether to override the installed toolchain to the working directory.
+        required: false
+        default: false
+    profile:
+        description: See https://rust-lang.github.io/rustup/concepts/profiles.html
+        required: false
+        default: "default"
+    components:
+        description: Space-separated list of components to be additionally installed.
+        required: false
+    working-directory:
+        description: The working directory.
+        required: false
+
+runs:
+    using: composite
+    steps:
+        - name: Set up toolchains.
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          run: |
+              set -x
+              rustup self update
+              rustup set profile ${{ inputs.profile }}
+              rustup toolchain install ${{ inputs.toolchain }}
+        - name: Set the default toolchain.
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          if: ${{ inputs.default == true }}
+          run: |
+              set -x
+              rustup default ${{ inputs.toolchain }}
+        - name: Set the toolchain override.
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          if: ${{ inputs.override }}
+          run: |
+              set -x
+              rustup override set ${{ inputs.toolchain }}
+        - name: Install additional compile targets.
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          if: ${{ inputs.target }}
+          run: |
+              set -x
+              rustup target add ${{ inputs.target }}
+        - name: Install additional toolchain componentns.
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          if: ${{ inputs.components }}
+          run: |
+              set -x
+              rustup component add ${{ inputs.components }}
+        - name: Installed toolchains' versions.
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          run: |
+              set -x
+              rustc --version
+              cargo --version
+        - name: Show the active and installed toolchains or profiles.
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          run: |
+              set -x
+              rustup show

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -101,11 +101,11 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Install Rust toolchain
-              uses: actions-rs/toolchain@v1
+              uses: ./.github/actions/rust-toolchain
               with:
                   toolchain: "1.66"
                   profile: default
-                  override: false
+                  override: true
 
             - shell: bash
               run: make format_check -j


### PR DESCRIPTION
It seems that https://github.com/actions-rs/toolchain is not maintained
actively.
We should replace it with simple rustup script.